### PR TITLE
Implement password reset flow

### DIFF
--- a/src/main/java/com/madiest/moapin/auth/password/PasswordResetController.java
+++ b/src/main/java/com/madiest/moapin/auth/password/PasswordResetController.java
@@ -1,0 +1,53 @@
+package com.madiest.moapin.auth.password;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
+/**
+ * REST endpoints for password reset operations.
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class PasswordResetController {
+    private final PasswordResetService service;
+
+    public PasswordResetController(PasswordResetService service) {
+        this.service = service;
+    }
+
+    public static class ResetRequest {
+        @NotBlank
+        private String email;
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+    }
+
+    public static class ResetConfirm {
+        @NotBlank
+        private String token;
+        @NotBlank
+        private String password;
+        public String getToken() { return token; }
+        public void setToken(String token) { this.token = token; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+    }
+
+    @PostMapping("/reset-request")
+    public ResponseEntity<Void> requestReset(@Valid @RequestBody ResetRequest req) {
+        service.createResetToken(req.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset")
+    public ResponseEntity<Void> reset(@Valid @RequestBody ResetConfirm req) {
+        service.resetPassword(req.getToken(), req.getPassword());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/madiest/moapin/auth/password/PasswordResetService.java
+++ b/src/main/java/com/madiest/moapin/auth/password/PasswordResetService.java
@@ -1,0 +1,78 @@
+package com.madiest.moapin.auth.password;
+
+import com.madiest.moapin.auth.User;
+import com.madiest.moapin.auth.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.services.sesv2.SesAsyncClient;
+import software.amazon.awssdk.services.sesv2.model.*;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service handling password reset flow.
+ */
+@Service
+public class PasswordResetService {
+    private final PasswordResetTokenRepository tokenRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final SesAsyncClient sesClient;
+
+    public PasswordResetService(PasswordResetTokenRepository tokenRepository,
+                                UserRepository userRepository,
+                                PasswordEncoder passwordEncoder,
+                                SesAsyncClient sesClient) {
+        this.tokenRepository = tokenRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.sesClient = sesClient;
+    }
+
+    /** Initiate password reset by creating a token and emailing the user. */
+    @Transactional
+    public void createResetToken(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.OK));
+        PasswordResetToken token = new PasswordResetToken();
+        token.setUser(user);
+        token.setToken(UUID.randomUUID().toString());
+        token.setExpiresAt(Instant.now().plusSeconds(3600));
+        tokenRepository.save(token);
+        sendEmail(user.getEmail(), token.getToken());
+    }
+
+    /** Reset the user's password using the token. */
+    @Transactional
+    public void resetPassword(String tokenStr, String newPassword) {
+        PasswordResetToken token = tokenRepository.findByToken(tokenStr)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid token"));
+        if (token.isUsed() || token.getExpiresAt().isBefore(Instant.now())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token expired");
+        }
+        User user = token.getUser();
+        user.setPassword(passwordEncoder.encode(newPassword));
+        token.setUsed(true);
+        userRepository.save(user);
+        tokenRepository.save(token);
+    }
+
+    private CompletableFuture<SendEmailResponse> sendEmail(String to, String token) {
+        Destination dest = Destination.builder().toAddresses(to).build();
+        Content subject = Content.builder().data("Password Reset").build();
+        Content bodyText = Content.builder().data("Use this token to reset your password: " + token).build();
+        Body body = Body.builder().text(bodyText).build();
+        Message message = Message.builder().subject(subject).body(body).build();
+        SendEmailRequest request = SendEmailRequest.builder()
+                .destination(dest)
+                .fromEmailAddress("noreply@example.com")
+                .content(EmailContent.builder().simple(message).build())
+                .build();
+        return sesClient.sendEmail(request);
+    }
+}

--- a/src/main/java/com/madiest/moapin/auth/password/PasswordResetToken.java
+++ b/src/main/java/com/madiest/moapin/auth/password/PasswordResetToken.java
@@ -1,0 +1,49 @@
+package com.madiest.moapin.auth.password;
+
+import com.madiest.moapin.auth.User;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+/**
+ * Entity representing a password reset token.
+ */
+@Entity
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private boolean used = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() { return id; }
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+    public boolean isUsed() { return used; }
+    public void setUsed(boolean used) { this.used = used; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/madiest/moapin/auth/password/PasswordResetTokenRepository.java
+++ b/src/main/java/com/madiest/moapin/auth/password/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.madiest.moapin.auth.password;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Repository for password reset tokens.
+ */
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+}

--- a/src/test/java/com/madiest/moapin/auth/PasswordResetIntegrationTest.java
+++ b/src/test/java/com/madiest/moapin/auth/PasswordResetIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.madiest.moapin.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.madiest.moapin.auth.password.PasswordResetTokenRepository;
+import com.madiest.moapin.auth.password.PasswordResetController.ResetConfirm;
+import com.madiest.moapin.auth.password.PasswordResetController.ResetRequest;
+import com.madiest.moapin.auth.payload.SignUpRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for password reset flow.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PasswordResetIntegrationTest {
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper mapper;
+    @Autowired private PasswordResetTokenRepository tokenRepo;
+    @Autowired private UserRepository userRepo;
+
+    @Test
+    void testPasswordResetFlow() throws Exception {
+        // register user
+        SignUpRequest signup = new SignUpRequest();
+        signup.setUsername("resetuser");
+        signup.setEmail("reset@example.com");
+        signup.setPassword("pass1234");
+        mvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(signup)))
+            .andExpect(status().isOk());
+
+        // request reset
+        ResetRequest req = new ResetRequest();
+        req.setEmail("reset@example.com");
+        mvc.perform(post("/api/auth/reset-request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(req)))
+            .andExpect(status().isOk());
+
+        // fetch token
+        Optional<com.madiest.moapin.auth.password.PasswordResetToken> tokenOpt =
+                tokenRepo.findAll().stream().findFirst();
+        assertThat(tokenOpt).isPresent();
+        String token = tokenOpt.get().getToken();
+
+        // reset password
+        ResetConfirm conf = new ResetConfirm();
+        conf.setToken(token);
+        conf.setPassword("newpass");
+        mvc.perform(post("/api/auth/reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(conf)))
+            .andExpect(status().isOk());
+
+        // verify password updated
+        User user = userRepo.findByUsername("resetuser").get();
+        assertThat(user.getPassword()).isNotEqualTo("pass1234");
+    }
+}


### PR DESCRIPTION
## Summary
- add password reset token entity and repo
- implement service and controller for password reset
- cover the flow with integration test

## Testing
- `./gradlew test` *(fails: Could not download lombok-1.18.38.jar)*

------
https://chatgpt.com/codex/tasks/task_e_688bf298bde48331bd8a33ca106d6be6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 비밀번호 재설정 기능이 추가되었습니다. 사용자는 이메일을 통해 비밀번호 재설정 요청 및 토큰을 이용한 비밀번호 변경이 가능합니다.

* **테스트**
  * 비밀번호 재설정 전체 흐름을 검증하는 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->