### PR TITLE
Implement share link generation

### DIFF
--- a/src/main/java/com/madiest/moapin/config/SecurityConfig.java
+++ b/src/main/java/com/madiest/moapin/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
         http.csrf().disable()
             .authorizeRequests()
                 .antMatchers("/api/auth/**", "/api/test/public", "/actuator/health").permitAll()
+                .antMatchers(org.springframework.http.HttpMethod.GET, "/api/share/**").permitAll()
                 .anyRequest().authenticated()
             .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);

--- a/src/main/java/com/madiest/moapin/share/ShareLink.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLink.java
@@ -1,0 +1,60 @@
+package com.madiest.moapin.share;
+
+import com.madiest.moapin.content.Content;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+/**
+ * Entity representing a shareable link for a content item.
+ */
+@Entity
+@Table(name = "share_link")
+public class ShareLink {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "max_downloads")
+    private Integer maxDownloads;
+
+    @Column(name = "download_count", nullable = false)
+    private long downloadCount = 0L;
+
+    @Column(nullable = false)
+    private boolean revoked = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() { return id; }
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public Content getContent() { return content; }
+    public void setContent(Content content) { this.content = content; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+    public Integer getMaxDownloads() { return maxDownloads; }
+    public void setMaxDownloads(Integer maxDownloads) { this.maxDownloads = maxDownloads; }
+    public long getDownloadCount() { return downloadCount; }
+    public void setDownloadCount(long downloadCount) { this.downloadCount = downloadCount; }
+    public boolean isRevoked() { return revoked; }
+    public void setRevoked(boolean revoked) { this.revoked = revoked; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/src/main/java/com/madiest/moapin/share/ShareLinkController.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkController.java
@@ -47,7 +47,7 @@ public class ShareLinkController {
     }
 
     @GetMapping
-    public List<ShareLink> list(@RequestParam Long contentId, Authentication auth) {
+    public List<ShareLink> list(@RequestParam @NotNull Long contentId, Authentication auth) {
         return service.listShareLinks(contentId, auth);
     }
 

--- a/src/main/java/com/madiest/moapin/share/ShareLinkController.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkController.java
@@ -1,0 +1,59 @@
+package com.madiest.moapin.share;
+
+import com.madiest.moapin.content.Content;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * REST controller for share link operations.
+ */
+@RestController
+@RequestMapping("/api/share")
+public class ShareLinkController {
+
+    private final ShareLinkService service;
+
+    public ShareLinkController(ShareLinkService service) {
+        this.service = service;
+    }
+
+    public static class CreateRequest {
+        @NotNull
+        private Long contentId;
+        private Instant expiresAt;
+        private Integer maxDownloads;
+        public Long getContentId() { return contentId; }
+        public void setContentId(Long contentId) { this.contentId = contentId; }
+        public Instant getExpiresAt() { return expiresAt; }
+        public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+        public Integer getMaxDownloads() { return maxDownloads; }
+        public void setMaxDownloads(Integer maxDownloads) { this.maxDownloads = maxDownloads; }
+    }
+
+    @PostMapping
+    public ShareLink create(@Valid @RequestBody CreateRequest req, Authentication auth) {
+        return service.createShareLink(req.getContentId(), req.getExpiresAt(), req.getMaxDownloads(), auth);
+    }
+
+    @GetMapping("/{token}")
+    public Content access(@PathVariable String token) {
+        return service.accessShareLink(token);
+    }
+
+    @GetMapping
+    public List<ShareLink> list(@RequestParam Long contentId, Authentication auth) {
+        return service.listShareLinks(contentId, auth);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> revoke(@PathVariable Long id, Authentication auth) {
+        service.revokeLink(id, auth);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/madiest/moapin/share/ShareLinkRepository.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkRepository.java
@@ -4,9 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.madiest.moapin.content.Content;
 
 import java.util.Optional;
-
+import java.util.List;
 /** Repository for share links. */
 public interface ShareLinkRepository extends JpaRepository<ShareLink, Long> {
     Optional<ShareLink> findByToken(String token);
-    java.util.List<ShareLink> findByContent(Content content);
+    List<ShareLink> findByContent(Content content);
 }

--- a/src/main/java/com/madiest/moapin/share/ShareLinkRepository.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkRepository.java
@@ -1,0 +1,12 @@
+package com.madiest.moapin.share;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.madiest.moapin.content.Content;
+
+import java.util.Optional;
+
+/** Repository for share links. */
+public interface ShareLinkRepository extends JpaRepository<ShareLink, Long> {
+    Optional<ShareLink> findByToken(String token);
+    java.util.List<ShareLink> findByContent(Content content);
+}

--- a/src/main/java/com/madiest/moapin/share/ShareLinkService.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkService.java
@@ -32,7 +32,8 @@ public class ShareLinkService {
         Content content = contentRepository.findById(contentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         // verify ownership via category service
-        if (content.getCategory() != null && !content.getCategory().getUser().getUsername().equals(auth.getName())) {
+        if (content.getCategory() != null && (content.getCategory().getUser() == null || 
+                !content.getCategory().getUser().getUsername().equals(auth.getName()))) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);
         }
         ShareLink link = new ShareLink();

--- a/src/main/java/com/madiest/moapin/share/ShareLinkService.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkService.java
@@ -72,8 +72,11 @@ public class ShareLinkService {
     @Transactional
     public void revokeLink(Long id, Authentication auth) {
         ShareLink link = repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        if (link.getContent().getCategory() != null && !link.getContent().getCategory().getUser().getUsername().equals(auth.getName())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        if (link.getContent().getCategory() != null) {
+            if (link.getContent().getCategory().getUser() == null || 
+                !link.getContent().getCategory().getUser().getUsername().equals(auth.getName())) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+            }
         }
         link.setRevoked(true);
         repository.save(link);

--- a/src/main/java/com/madiest/moapin/share/ShareLinkService.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkService.java
@@ -60,7 +60,7 @@ public class ShareLinkService {
     }
 
     @Transactional
-    public java.util.List<ShareLink> listShareLinks(Long contentId, Authentication auth) {
+    public List<ShareLink> listShareLinks(Long contentId, Authentication auth) {
         Content content = contentRepository.findById(contentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
         if (content.getCategory() != null && !content.getCategory().getUser().getUsername().equals(auth.getName())) {

--- a/src/main/java/com/madiest/moapin/share/ShareLinkService.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkService.java
@@ -1,0 +1,80 @@
+package com.madiest.moapin.share;
+
+import com.madiest.moapin.content.Content;
+import com.madiest.moapin.content.ContentRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Service for creating and accessing share links.
+ */
+@Service
+public class ShareLinkService {
+
+    private final ShareLinkRepository repository;
+    private final ContentRepository contentRepository;
+
+    public ShareLinkService(ShareLinkRepository repository,
+                            ContentRepository contentRepository) {
+        this.repository = repository;
+        this.contentRepository = contentRepository;
+    }
+
+    @Transactional
+    public ShareLink createShareLink(Long contentId, Instant expiresAt,
+                                     Integer maxDownloads, Authentication auth) {
+        Content content = contentRepository.findById(contentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        // verify ownership via category service
+        if (content.getCategory() != null && !content.getCategory().getUser().getUsername().equals(auth.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        ShareLink link = new ShareLink();
+        link.setContent(content);
+        link.setToken(UUID.randomUUID().toString());
+        link.setExpiresAt(expiresAt);
+        link.setMaxDownloads(maxDownloads);
+        return repository.save(link);
+    }
+
+    @Transactional
+    public Content accessShareLink(String token) {
+        ShareLink link = repository.findByToken(token)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (link.isRevoked() || (link.getExpiresAt() != null && link.getExpiresAt().isBefore(Instant.now()))) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Link expired");
+        }
+        if (link.getMaxDownloads() != null && link.getDownloadCount() >= link.getMaxDownloads()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Download limit reached");
+        }
+        link.setDownloadCount(link.getDownloadCount() + 1);
+        repository.save(link);
+        return link.getContent();
+    }
+
+    @Transactional
+    public java.util.List<ShareLink> listShareLinks(Long contentId, Authentication auth) {
+        Content content = contentRepository.findById(contentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (content.getCategory() != null && !content.getCategory().getUser().getUsername().equals(auth.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        return repository.findByContent(content);
+    }
+
+    @Transactional
+    public void revokeLink(Long id, Authentication auth) {
+        ShareLink link = repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        if (link.getContent().getCategory() != null && !link.getContent().getCategory().getUser().getUsername().equals(auth.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        link.setRevoked(true);
+        repository.save(link);
+    }
+}

--- a/src/main/java/com/madiest/moapin/share/ShareLinkService.java
+++ b/src/main/java/com/madiest/moapin/share/ShareLinkService.java
@@ -63,8 +63,10 @@ public class ShareLinkService {
     public List<ShareLink> listShareLinks(Long contentId, Authentication auth) {
         Content content = contentRepository.findById(contentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-        if (content.getCategory() != null && !content.getCategory().getUser().getUsername().equals(auth.getName())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        if (content.getCategory() != null) {
+            if (content.getCategory().getUser() == null || !content.getCategory().getUser().getUsername().equals(auth.getName())) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+            }
         }
         return repository.findByContent(content);
     }

--- a/src/test/java/com/madiest/moapin/share/ShareLinkServiceTest.java
+++ b/src/test/java/com/madiest/moapin/share/ShareLinkServiceTest.java
@@ -1,0 +1,57 @@
+package com.madiest.moapin.share;
+
+import com.madiest.moapin.content.Content;
+import com.madiest.moapin.content.ContentRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ShareLinkServiceTest {
+
+    @Test
+    void testCreateAndAccess() {
+        ShareLinkRepository repo = Mockito.mock(ShareLinkRepository.class);
+        ContentRepository contentRepo = Mockito.mock(ContentRepository.class);
+        ShareLinkService service = new ShareLinkService(repo, contentRepo);
+        Authentication auth = Mockito.mock(Authentication.class);
+        Mockito.when(auth.getName()).thenReturn("user");
+        Content content = new Content() {};
+        Mockito.when(contentRepo.findById(1L)).thenReturn(Optional.of(content));
+
+        Mockito.when(repo.save(Mockito.any())).thenAnswer(a -> a.getArguments()[0]);
+        ShareLink link = service.createShareLink(1L, Instant.now().plusSeconds(60), 1, auth);
+        assertThat(link.getToken()).isNotNull();
+
+        Mockito.when(repo.findByToken(link.getToken())).thenReturn(Optional.of(link));
+        Content accessed = service.accessShareLink(link.getToken());
+        assertThat(accessed).isSameAs(content);
+
+        assertThat(link.getDownloadCount()).isEqualTo(1);
+        assertThatThrownBy(() -> service.accessShareLink(link.getToken()))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Download limit");
+    }
+
+    @Test
+    void testExpired() {
+        ShareLinkRepository repo = Mockito.mock(ShareLinkRepository.class);
+        ContentRepository contentRepo = Mockito.mock(ContentRepository.class);
+        ShareLinkService service = new ShareLinkService(repo, contentRepo);
+        ShareLink link = new ShareLink();
+        link.setToken("t");
+        link.setExpiresAt(Instant.now().minusSeconds(1));
+        Mockito.when(repo.findByToken("t")).thenReturn(Optional.of(link));
+
+        assertThatThrownBy(() -> service.accessShareLink("t"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("expired");
+    }
+}


### PR DESCRIPTION
## Summary
- add share link entity, repository, service and controller
- allow GET `/api/share/**` requests without authentication
- unit test for ShareLinkService

## Testing
- `./gradlew test --no-daemon --offline` *(fails: Could not download lombok, no cached version available)*

------
https://chatgpt.com/codex/tasks/task_e_688bf53355b8833180f3245060822e1d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 콘텐츠에 대한 공유 링크 생성, 조회, 목록 확인, 만료 및 다운로드 제한 설정, 링크 폐기 기능이 추가되었습니다.
  * 공유 링크를 통해 인증 없이 콘텐츠에 접근할 수 있습니다(GET /api/share/**).
* **버그 수정**
  * 해당 없음.
* **테스트**
  * 공유 링크 서비스의 생성, 접근, 만료 및 다운로드 제한 동작에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->