### PR TITLE
chore(api-docs): disable Swagger in prod

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,3 +31,9 @@ management:
   endpoint:
     health:
       show-details: always
+
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,3 +36,9 @@ management:
   endpoint:
     health:
       show-details: when_authorized
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
Disables springdoc API docs & Swagger UI in production profile. Explicitly enables in dev.\n\nCloses #30\n\nChanges:\n- application-prod.yml: springdoc.api-docs.enabled=false, swagger-ui.enabled=false\n- application-dev.yml: explicitly enabled both\n\nAcceptance Criteria:\n- Accessing /v3/api-docs under prod profile returns 404\n- Swagger UI not served in prod\n- Dev profile remains accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 개발 환경에서 OpenAPI 기반 API 문서와 Swagger UI가 활성화되어 브라우저에서 확인·검색·탐색이 가능합니다. 문서 화면과 인터랙티브 테스트가 지원됩니다.
- 작업
  - 운영 환경에서 API 문서와 Swagger UI를 비활성화했습니다. 환경별로 문서 엔드포인트와 UI 노출 범위를 분리하여, 개발에서만 문서가 표시되고 운영에서는 표시되지 않도록 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->